### PR TITLE
Update for API version 7.X (JSON) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,37 @@ require 'ahsay-api-wrapper.php';
 const  BACKUPSERVER_ADDRESS       = 'http://ahsay.server.com';
 const  BACKUPSERVER_ADMINUSER     = 'adminuser';
 const  BACKUPSERVER_ADMINPASSWORD = 'password';
+const  BACKUPSERVER_VERSION        = 'OBSversion';
 
 try {
-    $api = new AhsayApiWrapper(BACKUPSERVER_ADDRESS, BACKUPSERVER_ADMINUSER, BACKUPSERVER_ADMINPASSWORD);
+    $api = new AhsayApiWrapper(BACKUPSERVER_ADDRESS, BACKUPSERVER_ADMINUSER, BACKUPSERVER_ADMINPASSWORD, BACKUPSERVER_VERSION);
 
     $api->debug(true);
-
+   
     $user = 'user01'; // Ahsay username
     $backupSet = '1317401234567'; // Ahsay numeric backupset ID
 
     $lastJobID = $api->getMostRecentBackupJob($user, $backupSet);
-    $lastJobDetailArray = $api->getUserBackupJobDetails($user, $backupSet, $lastJobID)['@attributes'];
+    $lastJobDetailArray = $api->getUserBackupJobDetails($user, $backupSet, $lastJobID);
+    $DestinationID = $api->getDestinationID($user, $backupSet, $backupJob);
 
-    //var_dump($lastJobDetailArray);
-    printf('BackupJobStatus: '.$lastJobDetailArray['BackupJobStatus']."\n");
-    printf('EndTime: '.$lastJobDetailArray['EndTime']);
+    //var_dump($api->getUser($user));
+    //var_dump($api->getUSerBackupSet($user, $backupSet));
+    //var_dump($api->getUserStorageStats($user, $date));
+    //var_dump($api->getBackupJobsForSet($user, $backupSet));
+    //var_dump($api->getBackupSetJobIds($user, $backupSet));
+    //var_dump($api->listBackupJobStatus($user, $date));
+    //var_dump($api->getUserBackupJobs($user));
+    //var_dump($api->getMostRecentBackupJob($user, $backupset));
+
+    printf ('DestinationID: ' . $DestinationID . "\n\r");
+    printf('BackupJobStatus: '. $lastJobDetailArray->Data->BackupJobStatus . "\n");
+    printf('EndTime: '. $lastJobDetailArray->Data->EndTime . "\n");
+
 } catch (Exception $e) {
     echo $e->GetMessage();
 }
-
+?>
 ```
 ## Known issues / limitations
 Some API calls are known to be missing.  You are welcome to write the code for these functions yourself and submit the necessary code to me for inclusion in future releases of this library.

--- a/ahsay-api-wrapper-example.php
+++ b/ahsay-api-wrapper-example.php
@@ -4,34 +4,35 @@ require 'ahsay-api-wrapper.php';
 const  BACKUPSERVER_ADDRESS       = 'http://ahsay.server.com';
 const  BACKUPSERVER_ADMINUSER     = 'adminuser';
 const  BACKUPSERVER_ADMINPASSWORD = 'password';
-const  BACKUPSERVER_VERSION        = 'OBSversion';
+const  BACKUPSERVER_VERSION       = 'OBSversion';
 
 try {
-    $api = new AhsayApiWrapper(BACKUPSERVER_ADDRESS, BACKUPSERVER_ADMINUSER, BACKUPSERVER_ADMINPASSWORD, BACKUPSERVER_VERSION);
+  $api = new AhsayApiWrapper(BACKUPSERVER_ADDRESS, BACKUPSERVER_ADMINUSER, BACKUPSERVER_ADMINPASSWORD, BACKUPSERVER_VERSION);
 
-    $api->debug(true);
-   
-    $user = 'user01'; // Ahsay username
-    $backupSet = '1317401234567'; // Ahsay numeric backupset ID
+  $api->debug(true);
 
-    $lastJobID = $api->getMostRecentBackupJob($user, $backupSet);
-    $lastJobDetailArray = $api->getUserBackupJobDetails($user, $backupSet, $lastJobID);
-    $DestinationID = $api->getDestinationID($user, $backupSet, $backupJob);
+  $user = 'user01'; // Ahsay username
+  $backupSet = '1317401234567'; // Ahsay numeric backupset ID
 
-    //var_dump($api->getUser($user));
-    //var_dump($api->getUSerBackupSet($user, $backupSet));
-    //var_dump($api->getUserStorageStats($user, $date));
-    //var_dump($api->getBackupJobsForSet($user, $backupSet));
-    //var_dump($api->getBackupSetJobIds($user, $backupSet));
-    //var_dump($api->listBackupJobStatus($user, $date));
-    //var_dump($api->getUserBackupJobs($user));
-    //var_dump($api->getMostRecentBackupJob($user, $backupset));
+  $lastJobID = $api->getMostRecentBackupJob($user, $backupSet);
+  $lastJobDetailArray = $api->getUserBackupJobDetails($user, $backupSet, $lastJobID);
+  $DestinationID = $api->getDestinationID($user, $backupSet, $backupJob);
 
-    printf ('DestinationID: ' . $DestinationID . "\n\r");
-    printf('BackupJobStatus: '. $lastJobDetailArray->Data->BackupJobStatus . "\n");
-    printf('EndTime: '. $lastJobDetailArray->Data->EndTime . "\n");
+  //var_dump($api->getUser($user));
+  //var_dump($api->getUSerBackupSet($user, $backupSet));
+  //var_dump($api->getUserStorageStats($user, $date));
+  //var_dump($api->getBackupJobsForSet($user, $backupSet));
+  //var_dump($api->getBackupSetJobIds($user, $backupSet));
+  //var_dump($api->listBackupJobStatus($user, $date));
+  //var_dump($api->getUserBackupJobs($user));
+  //var_dump($api->getMostRecentBackupJob($user, $backupset));
+
+  printf ('DestinationID: ' . $DestinationID . "\n\r");
+  printf('BackupJobStatus: '. $lastJobDetailArray->Data->BackupJobStatus . "\n");
+  printf('EndTime: '. $lastJobDetailArray->Data->EndTime . "\n");
 
 } catch (Exception $e) {
-    echo $e->GetMessage();
+  echo $e->GetMessage();
 }
+
 ?>

--- a/ahsay-api-wrapper-example.php
+++ b/ahsay-api-wrapper-example.php
@@ -4,21 +4,34 @@ require 'ahsay-api-wrapper.php';
 const  BACKUPSERVER_ADDRESS       = 'http://ahsay.server.com';
 const  BACKUPSERVER_ADMINUSER     = 'adminuser';
 const  BACKUPSERVER_ADMINPASSWORD = 'password';
+const  BACKUPSERVER_VERSION        = 'OBSversion';
 
 try {
-    $api = new AhsayApiWrapper(BACKUPSERVER_ADDRESS, BACKUPSERVER_ADMINUSER, BACKUPSERVER_ADMINPASSWORD);
+    $api = new AhsayApiWrapper(BACKUPSERVER_ADDRESS, BACKUPSERVER_ADMINUSER, BACKUPSERVER_ADMINPASSWORD, BACKUPSERVER_VERSION);
 
     $api->debug(true);
-
+   
     $user = 'user01'; // Ahsay username
     $backupSet = '1317401234567'; // Ahsay numeric backupset ID
 
     $lastJobID = $api->getMostRecentBackupJob($user, $backupSet);
-    $lastJobDetailArray = $api->getUserBackupJobDetails($user, $backupSet, $lastJobID)['@attributes'];
+    $lastJobDetailArray = $api->getUserBackupJobDetails($user, $backupSet, $lastJobID);
+    $DestinationID = $api->getDestinationID($user, $backupSet, $backupJob);
 
-    //var_dump($lastJobDetailArray);
-    printf('BackupJobStatus: '.$lastJobDetailArray['BackupJobStatus']."\n");
-    printf('EndTime: '.$lastJobDetailArray['EndTime']);
+    //var_dump($api->getUser($user));
+    //var_dump($api->getUSerBackupSet($user, $backupSet));
+    //var_dump($api->getUserStorageStats($user, $date));
+    //var_dump($api->getBackupJobsForSet($user, $backupSet));
+    //var_dump($api->getBackupSetJobIds($user, $backupSet));
+    //var_dump($api->listBackupJobStatus($user, $date));
+    //var_dump($api->getUserBackupJobs($user));
+    //var_dump($api->getMostRecentBackupJob($user, $backupset));
+
+    printf ('DestinationID: ' . $DestinationID . "\n\r");
+    printf('BackupJobStatus: '. $lastJobDetailArray->Data->BackupJobStatus . "\n");
+    printf('EndTime: '. $lastJobDetailArray->Data->EndTime . "\n");
+
 } catch (Exception $e) {
     echo $e->GetMessage();
 }
+?>

--- a/ahsay-api-wrapper.php
+++ b/ahsay-api-wrapper.php
@@ -56,6 +56,20 @@ class AhsayApiWrapper
     $this->debug = $which;
   }
 
+  // Get Ahsay OBS License informations
+  public function getLicense()
+  {
+    $this->debugLog("Get Ahsay OBS license informations");
+
+    $url = "/GetLicense.do";
+    $result = $this->runQuery($url);
+
+    // If that didn't happen
+    $this->errorHandler($result, "Failed to get Ahsay OBS License informations.");
+
+    return $this->decodeResult($result);
+  }
+
   // Authenticate a user against OBS
   public function authenticateUser($username, $password)
   {
@@ -314,7 +328,7 @@ class AhsayApiWrapper
   public function runQuery($url)
   {
     try {
-      if ($this->serverVersion == '6') {
+      if ($this->serverVersion === '6') {
         $url = $this->serverAddress.'/obs/api'.$url;
 
         // If this URL already has a query string
@@ -327,7 +341,7 @@ class AhsayApiWrapper
         $this->debuglog("Trying $url");
         $result = file_get_contents($url);
 
-      } elseif ($this->serverVersion == '7') {
+      } elseif ($this->serverVersion === '7') {
         if (strstr($url, '?')) {
           $args=explode('&', substr($url, strpos($url, '?') +1));
           $url = $this->serverAddress.'/obs/api/json'.strstr($url, '?', TRUE);
@@ -375,9 +389,9 @@ class AhsayApiWrapper
   public function decodeResult($result)
   {
     try {
-      if ($this->serverVersion == '6') {
+      if ($this->serverVersion === '6') {
         return simplexml_load_string($result);
-      } elseif ($this->serverVersion == '7') {
+      } elseif ($this->serverVersion === '7') {
         return json_decode($result);
       } else {
         throw new Exception("Please specify server version between 6 or 7 !\e\n");
@@ -392,13 +406,13 @@ class AhsayApiWrapper
   public function errorHandler($result, $message)
   {
     try {
-      if ($this->serverVersion == '6') {
-        if (substr($result, 1, 3) == 'err') {
+      if ($this->serverVersion === '6') {
+        if (substr($result, 1, 3) === 'err') {
           throw new Exception($message . "\r\n" . $result . "\r\n");
         }
-      } elseif ($this->serverVersion == '7') {
+      } elseif ($this->serverVersion === '7') {
         $status=json_decode($result, TRUE);
-        if ($status['Status'] == 'Error') {
+        if ($status['Status'] === 'Error') {
           throw new Exception($message . "\r\n" . $result . "\r\n");
         }
       } else {

--- a/ahsay-api-wrapper.php
+++ b/ahsay-api-wrapper.php
@@ -1,12 +1,12 @@
 <?php
 /*
 
-PHP API wrapper for AhsayOBS. Version 1.10
+PHP API wrapper for AhsayOBS. Version 1.20
 
-Copyright (C)  2015
+Copyright (C)  2016
 Hannes Van de Vel (h@nnes.be),
-Richard Bishop (ahsayapi@uchange.co.uk).
-
+Richard Bishop (ahsayapi@uchange.co.uk),
+Christophe Aubry (christophe.aubry1984@gmail.com).
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -25,276 +25,410 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 class AhsayApiWrapper
 {
-    public $serverAddress;
-    public $serverAdminUsername;
-    public $serverAdminPassword;
-    public $debug;
-    public $error;
+  public $serverAddress;
+  public $serverAdminUsername;
+  public $serverAdminPassword;
+  public $debug;
+  public $error;
 
-    /*
-    Note:
-    All times (user added, backupset last run, completed etc) are in the form
-    of Unix timestamps.  In the case of Java this is the number of milliseconds
-    since Jan 1st 1970; though PHP counts this as seconds since Jan 1st 1970.
-    The solution is to disregard the final 3 digits of the value output by OBS
-    */
+  /*
+  Note:
+  All times (user added, backupset last run, completed etc) are in the form
+  of Unix timestamps.  In the case of Java this is the number of milliseconds
+  since Jan 1st 1970; though PHP counts this as seconds since Jan 1st 1970.
+  The solution is to disregard the final 3 digits of the value output by OBS
+  */
 
-    // Constructor
-    public function __construct($address, $username, $password)
-    {
-        $this->serverAddress = rtrim($address, '/'); // Remove trailing slash
-        $this->serverAdminUsername = $username;
-        $this->serverAdminPassword = $password;
-        $this->debug;
-    }
+  // Constructor
+  public function __construct($address, $username, $password, $version)
+  {
+    $this->serverAddress = rtrim($address, '/'); // Remove trailing slash
+    $this->serverAdminUsername = $username;
+    $this->serverAdminPassword = $password;
+    $this->serverVersion = $version; // Choose between Ahsay OBS v6 or v7
+    $this->debug;
+  }
 
-    // Enable/disable debugging
-    public function debug($which)
-    {
-        $this->debug = $which;
-    }
+  // Enable/disable debugging
+  public function debug($which)
+  {
+    $this->debug = $which;
+  }
 
-    // Authenticate a user against OBS
-    public function authenticateUser($username, $password)
-    {
-        $this->debuglog("Authenticate user $username");
+  // Authenticate a user against OBS
+  public function authenticateUser($username, $password)
+  {
+    $this->debuglog("Authenticate user $username");
 
-        $url = '/obs/api/AuthUser.do?';
-        $url .= 'LoginName='.$username.'&Password='.$password;
-        $result = $this->runQuery($url);
+    $url = "/AuthUser.do?LoginName=$username&Password=$password";
+    $result = $this->runQuery($url);
 
-        // If that didn't happen
-        if (substr($result, 0, 3) == 'err') {
-            throw new Exception("Authenticate user failed. $result");
-        }
-        return 'OK';
-    }
+    // If that didn't happen
+    $this->errorHandler($result, "Authenticate user failed.");
 
-    // Get a particular user
-    public function getUser($username)
-    {
-        $this->debuglog("Getting user '$username'");
+    return 'OK';
+  }
 
-        $url = "/obs/api/GetUser.do?LoginName=$username";
-        $result = $this->runQuery($url);
+  // Get a particular user
+  public function getUser($username)
+  {
+    $this->debuglog("Getting user '$username'");
 
-        // If that didn't happen
-        if (substr($result, 0, 3) == 'err') {
-            throw new Exception("No user details found for '$username'. $result");
-        }
+    $url = "/GetUser.do?LoginName=$username";
+    $result = $this->runQuery($url);
 
-        return simplexml_load_string($result);
-    }
+    // If that didn't happen
+    $this->errorHandler($result, "No user details found for '$username'.");
 
-    // Get an array of all users
-    public function getUsers()
-    {
-        $this->debuglog('Getting user list');
+    return $this->decodeResult($result);
+  }
 
-        $url = '/obs/api/ListUsers.do';
-        $result = $this->runQuery($url);
+  // Get an array of all users
+  public function getUsers()
+  {
+    $this->debuglog("Getting user list");
 
-        // If that didn't happen
-        if (substr($result, 1, 3) == 'err') {
-            throw new Exception("Problem during getUsers(). $result");
-        }
-        return simplexml_load_string($result);
-    }
+    $url = "/ListUsers.do";
+    $result = $this->runQuery($url);
 
-    // Get all backup sets for a particular user
-    public function getUserBackupSets($username)
-    {
-        $this->debuglog("Getting backup sets for user '$username'");
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during getUsers().");
 
-        $url = "/obs/api/ListBackupSets.do?LoginName=$username";
-        $result = $this->runQuery($url);
+    return $this->decodeResult($result);
+  }
 
-        // If that didn't happen
-        if (substr($result, 1, 3) == 'err') {
-            throw new Exception("Problem during getUserBackupSets() for '$username'. $result");
-        }
-        return simplexml_load_string($result);
-    }
+  // Get all backup sets for a particular user
+  public function getUserBackupSets($username)
+  {
+    $this->debuglog("Getting backup sets for user '$username'");
 
-    // Get storage statistics for a particular user
-    public function getUserStorageStats($username, $date)
-    {
-        $this->debuglog("Getting storage stats for user '$username'");
+    $url = "/ListBackupSets.do?LoginName=$username";
+    $result = $this->runQuery($url);
 
-        $url = "/obs/api/GetUserStorageStat.do?LoginName=$username&YearMonth=$date";
-        $this->debuglog($url);
-        $result = $this->runQuery($url);
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during getUserBackupSets() for '$username'.");
 
-        // If that didn't happen
-        if (substr($result, 1, 3) == 'err') {
-            throw new Exception("Problem during getUserStorageStats() for '$username'. $result");
-        }
-        return simplexml_load_string($result);
-    }
+    return $this->decodeResult($result);
+  }
 
-    // Get all backup jobs for a particular user
-    public function getUserBackupJobs($username)
-    {
-        $this->debuglog("Getting backup jobs for user '$username'");
+  // Get storage statistics for a particular user
+  public function getUserStorageStats($username, $date)
+  {
+    $this->debuglog("Getting storage stats for user '$username'");
 
-        $url = "/obs/api/ListBackupJobs.do?LoginName=$username";
-        $result = $this->runQuery($url);
+    $url = "/GetUserStorageStat.do?LoginName=$username&YearMonth=$date";
+    $this->debuglog($url);
+    $result = $this->runQuery($url);
 
-        // If that didn't happen
-        if (substr($result, 1, 3) == 'err') {
-            throw new Exception("Problem during getUserBackupJobs() for '$username'. $result");
-        }
-        return simplexml_load_string($result);
-    }
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during getUserStorageStats() for '$username'.");
 
-    // Get all backup jobs for a particular user, limited to a particular backup set
-    public function getBackupJobsForSet($username, $backupset)
-    {
-        $this->debuglog("Getting backup jobs for user '$username', for backup set with id '$backupset'");
+    return $this->decodeResult($result);
+  }
 
-        $url = "/obs/api/ListBackupJobs.do?LoginName=$username";
-        $result = $this->runQuery($url);
+  // Get all backup jobs for a particular user
+  public function getUserBackupJobs($username)
+  {
+    $this->debuglog("Getting backup jobs for user '$username'");
 
-        // If that didn't happen
-        if (substr($result, 1, 3) == 'err') {
-            throw new Exception("Problem during getBackupJobsForSet() for '$username', for backup set with id '$backupset'. $result");
-        }
-        $data = simplexml_load_string($result);
+    $url = "/ListBackupJobs.do?LoginName=$username";
+    $result = $this->runQuery($url);
 
-        foreach ($data->BackupSet as $set) {
-            // If this is the backupset we are interested in
-            if ($set['ID'] == $backupset) {
-                $this->debuglog(sizeof($set)." job(s) found for set '$backupset'");
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during getUserBackupJobs() for '$username'.");
 
-                return $set;
-            }
-        }
-        // If we get to here then that backup set obviously doesn't exist!
-        throw new Exception("Problem doing getBackupJobsForSet() - looks like set '$backupset' doesn't exist");
-    }
+    return $this->decodeResult($result);
+  }
 
-    // Get the IDs of each backup job for this set in reverse order
-    public function getBackupSetJobIds($username, $backupset, $rev)
-    {
-        $rev = false;
+  // Get all backup jobs for a particular user, limited to a particular backup set
+  public function getBackupJobsForSet($username, $backupset)
+  {
+    $this->debuglog("Getting backup jobs for user '$username', for backup set with id '$backupset'");
 
-        $this->debuglog("Getting list of backup job ids for user '$username', for backup set with id '$backupset'");
+    $url = "/ListBackupJobs.do?LoginName=$username";
+    $result = $this->runQuery($url);
 
-        // Get a list of all backup jobs for this backup set
-        $jobs = $this->getBackupJobsForSet($username, $backupset);
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during getBackupJobsForSet() for '$username', for backup set with id '$backupset'.");
 
-        if (sizeof($jobs) <= 0) {
-            throw new Exception("Could not run getUserBackupJobsForSet() in getBackupSetJobIds() for backup set id '$backupset'.");
-        }
+    $data = $this->decodeResult($result);
 
-        // Go through each job id
-        //         $backupSets = array();
-
-        foreach ($jobs->BackupJob as $job) {
+    if ($this->serverVersion == '6') {
+      foreach ($data->children() as $set) {
+        // If this is the backupset we are interested in
+        if ($set['ID'] == $backupset) {
+          $this->debuglog(sizeof($set)." job(s) found for set '$backupset'");
+          // Go through each job id
+          foreach ($set->BackupJob as $job) {
             $backupJobs[] = (string) $job['ID'];
-        }
+          }
 
-        // Sort in reverse?
-        if ($rev) {
-            rsort($backupJobs);
+          return $backupJobs;
         }
-        if (!$rev) {
-            sort($backupJobs);
-        }
+      }
+    } elseif ($this->serverVersion == '7') {
+      foreach ($data->Data as $set) {
+        // If this is the backupset we are interested in
+        if ($set->BackupSetID == $backupset) {
+          $this->debuglog(sizeof($set->BackupJob)." job(s) found for set '$backupset'");
 
-        return $backupJobs;
+          return $set->BackupJob;
+        }
+      }
+    }
+    // If we get to here then that backup set obviously doesn't exist!
+    $this->errorHandler($result, "Problem doing getBackupJobsForSet() - looks like set '$backupset' doesn't exist");
+  }
+
+  // Get the IDs of each backup job for this set in reverse order
+  public function getBackupSetJobIds($username, $backupset, $rev)
+  {
+    if(isset($rev) === false) {
+      $rev = false;
     }
 
-    // Get the ID of the most recent job for this backup set
-    public function getMostRecentBackupJob($username, $backupset)
-    {
-        $this->debuglog("Running getMostRecentBackupJob() for backup set with id '$backupset'");
+    $this->debuglog("Getting list of backup job ids for user '$username', for backup set with id '$backupset'");
 
-        // Get a list of all backup jobs for this backup set (in reverse order)
-        $jobs = $this->getBackupSetJobIds($username, $backupset, true);
-        if (!$jobs) {
-            throw new Exception("Could not run getBackupSetJobIds() in getMostRecentBackupJob() for backup set id '$backupset'.");
-        }
+    // Get a list of all backup jobs for this backup set
+    $jobs = $this->getBackupJobsForSet($username, $backupset);
 
-        // Return just the most recent
-        return $jobs[0];
+    if (sizeof($jobs) <= 0) {
+      throw new Exception("Could not run getUserBackupJobsForSet() in getBackupSetJobIds() for backup set id '$backupset'.");
     }
 
-    // Get all backup jobs for a particular user
-    public function getUserBackupJobDetails($username, $backupset, $backupjob)
-    {
-        $this->debuglog("Getting backup job details for user '$username', job id '$backupjob'");
+    // Sort in reverse?
+    if ($rev) {
+      rsort($jobs);
+    }
+    if (!$rev) {
+      sort($jobs);
+    }
 
-        $url = "/obs/api/GetBackupJobReport.do?LoginName=$username&BackupSetID=$backupset&BackupJobID=$backupjob";
-        $result = $this->runQuery($url);
+    return $jobs;
+  }
 
-        // If that didn't happen
-        if (substr($result, 1, 3) == 'err') {
-            throw new Exception("Problem during getUserBackupJobDetails() for '$username', job id '$backupjob'. $result");
+  // Get the ID of the most recent job for this backup set
+  public function getMostRecentBackupJob($username, $backupset)
+  {
+    $this->debuglog("Running getMostRecentBackupJob() for backup set with id '$backupset'");
+
+    // Get a list of all backup jobs for this backup set (in reverse order)
+    $jobs = $this->getBackupSetJobIds($username, $backupset, true);
+    if (!$jobs) {
+      throw new Exception("Could not run getBackupSetJobIds() in getMostRecentBackupJob() for backup set id '$backupset'.");
+    }
+
+    // Return just the most recent
+    return $jobs[0];
+  }
+
+  // Get all backup jobs for a particular user
+  public function getUserBackupJobDetails($username, $backupset, $backupjob)
+  {
+
+    $this->debuglog("Getting backup job details for user '$username', job id '$backupjob'");
+
+    $destinationid = $this->getDestinationID($username, $backupset, $backupjob);
+
+    if(isset($destinationid) === false) {
+      $destinationid='0';
+    }
+
+    $this->debuglog("Getting backup job details for user '$username', job id '$backupjob'");
+
+    $url = "/GetBackupJobReport.do?LoginName=$username&BackupSetID=$backupset&BackupJobID=$backupjob&DestinationID=$destinationid";
+    $result = $this->runQuery($url);
+
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during getUserBackupJobDetails() for '$username', job id '$backupjob'. $result");
+
+    return $this->decodeResult($result);
+  }
+
+  // Get details on a particular backup set
+  public function getUserBackupSet($username, $backupset)
+  {
+    $this->debuglog("Getting details for backup set with id '$setid' for user '$username'");
+
+    $url = "/GetBackupSet.do?LoginName=$username&BackupSetID=$backupset";
+    $result = $this->runQuery($url);
+
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during getUserBackupSet() for $username. $result");
+
+    return $this->decodeResult($result);
+  }
+
+  // Get status of a user backup job for a particular date in (yyyy-MM-dd format)
+  public function listBackupJobStatus($username, $date)
+  {
+    if (isset($date) === false) {
+      $date = date("-Y-m-d");
+    }
+
+    $this->debuglog("Getting status for backup job that run on the '$date' for user '$username'");
+
+    $url = "/ListBackupJobStatus.do?LoginName=$username&BackupDate=$date";
+    $result = $this->runQuery($url);
+
+    // If that didn't happen
+    $this->errorHandler($result, "Problem during listBackupJobStatus() for $username. $result");
+
+    return $this->decodeResult($result);
+
+  }
+
+  // Retrieve the DestinationID of a backup job for a particular backupset of a given user
+  public function getDestinationID($username, $backupset, $backupjob)
+  {
+
+    $date = substr($backupjob, 0, 10);
+
+    $this->debuglog("Getting the destination of the backup job '$backupjob' for user '$username'");
+
+    $data = $this->listBackupJobStatus($username, $date);
+
+    if ($this->serverVersion === '6') {
+      foreach($data->children() as $backupjobstatus) {
+        if (strval($backupjobstatus['BackupSetID']) === $backupset && strval($backupjobstatus['ID']) === $backupjob) {
+          $this->debuglog("Destination found for backup set '$backupset' and backup job '$backupjob'");
+          $result = $backupjobstatus['DestinationID'];
         }
+
+        return $result;
+      }
+    } elseif ($this->serverVersion === '7') {
+      foreach($data->Data as $backupjobstatus) {
+        if ($backupjobstatus->BackupSetID === $backupset && $backupjobstatus->ID === $backupjob) {
+          $this->debuglog("Destination found for backup set '$backupset' and backup job '$backupjob'");
+          $result = $backupjobstatus->DestinationID;
+        }
+      }
+
+      return $result;
+    }
+  }
+
+  // Run an API query against OBS
+  public function runQuery($url)
+  {
+    try {
+      if ($this->serverVersion == '6') {
+        $url = $this->serverAddress.'/obs/api'.$url;
+
+        // If this URL already has a query string
+        if (strstr($url, '?')) {
+          $url .= '&SysUser='.$this->serverAdminUsername.'&SysPwd='.$this->serverAdminPassword;
+        }
+        if (!strstr($url, '?')) {
+          $url .= '?SysUser='.$this->serverAdminUsername.'&SysPwd='.$this->serverAdminPassword;
+        }
+        $this->debuglog("Trying $url");
+        $result = file_get_contents($url);
+
+      } elseif ($this->serverVersion == '7') {
+        if (strstr($url, '?')) {
+          $args=explode('&', substr($url, strpos($url, '?') +1));
+          $url = $this->serverAddress.'/obs/api/json'.strstr($url, '?', TRUE);
+
+          foreach ($args as $arg) {
+            list($k, $v) = explode('=', $arg);
+            $postData[$k] = $v;
+          }
+        } elseif (!strstr($url, '?')) {
+          $url = $this->serverAddress.'/obs/api/json'. $url;
+          $postData = array();
+        }
+
+        $postData['SysUser'] = $this->serverAdminUsername;
+        $postData['SysPwd'] = $this->serverAdminPassword;
+
+        $curlreq = curl_init($url);
+        curl_setopt_array($curlreq, array (
+          CURLOPT_POST  =>  TRUE,
+          CURLOPT_RETURNTRANSFER =>  TRUE,
+          CURLOPT_HTTPHEADER => array (
+            'Authorization: Ahsay OBS JSON API v7.X',
+            'Content-Type: application/json'
+          ),
+          CURLOPT_POSTFIELDS  =>  json_encode($postData)
+          )
+        );
+
+        $this->debuglog("Trying $url");
+        $result = curl_exec($curlreq);
+
+      } else {
+        throw new Exception("Please specify server version between 6 or 7 !\r\n");
+      }
+
+      return $result;
+    }
+
+    catch (Exception $e) {
+      throw new Exception("Error accessing API: ".$e->GetMessage());
+    }
+  }
+
+  // Decode XML from Ahsay OBS 6.X API and JSON from Ahsay version 7.X API
+  public function decodeResult($result)
+  {
+    try {
+      if ($this->serverVersion == '6') {
         return simplexml_load_string($result);
+      } elseif ($this->serverVersion == '7') {
+        return json_decode($result);
+      } else {
+        throw new Exception("Please specify server version between 6 or 7 !\e\n");
+      }
     }
+    catch (Exception $e) {
+      throw new Exception("Error accessing API: ".$e->GetMessage());
+    }
+  }
 
-    // Get details on a particular backup set
-    public function getUserBackupSet($username, $setid)
-    {
-        $this->debuglog("Getting details for backup set with id '$setid' for user '$username'");
-
-        $url = "/obs/api/GetBackupSet.do?LoginName=$username&BackupSetID=$setid";
-        $result = $this->runQuery($url);
-
-        // If that didn't happen
+  // Handle error returned from the OBS API
+  public function errorHandler($result, $message)
+  {
+    try {
+      if ($this->serverVersion == '6') {
         if (substr($result, 1, 3) == 'err') {
-            throw new Exception("Problem during getUserBackupSet() for $username. $result");
+          throw new Exception($message . "\r\n" . $result . "\r\n");
         }
-        return simplexml_load_string($result);
-    }
-
-    // Run an API query against OBS
-    public function runQuery($url)
-    {
-        try {
-            $url = $this->serverAddress.$url;
-
-            // If this URL already has a query string
-            if (strstr($url, '?')) {
-                $url .= '&SysUser='.$this->serverAdminUsername.'&SysPwd='.$this->serverAdminPassword;
-            }
-            if (!strstr($url, '?')) {
-                $url .= '?SysUser='.$this->serverAdminUsername.'&SysPwd='.$this->serverAdminPassword;
-            }
-
-            $this->debuglog("Trying $url");
-            $result = file_get_contents($url);
-            if ($result === false) {
-                throw new Exception("Error accessing API");
-            }
-            return $result;
-        } catch (Exception $e) {
-            throw new Exception("Error accessing API: ".$e->GetMessage());
+      } elseif ($this->serverVersion == '7') {
+        $status=json_decode($result, TRUE);
+        if ($status['Status'] == 'Error') {
+          throw new Exception($message . "\r\n" . $result . "\r\n");
         }
+      } else {
+        throw new Exception("Please specify server version between 6 or 7 !\r\n");
+      }
     }
-
-    public function formatBytes($bytes, $precision = 2)
-    {
-        $units = array('B', 'KB', 'MB', 'GB', 'TB');
-
-        $bytes = max($bytes, 0);
-        $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
-        $pow = min($pow, count($units) - 1);
-
-        // Uncomment one of the following alternatives
-        $bytes /= pow(1024, $pow);
-        // $bytes /= (1 << (10 * $pow));
-
-        return round($bytes, $precision).' '.$units[$pow];
+    catch (Exception $e) {
+      throw new Exception("Error accessing API: ".$e->GetMessage());
     }
+  }
 
-    // Debug logging
-    public function debuglog($message)
-    {
-        if ($this->debug) {
-            printf("%s\n", $message);
-        }
+  public function formatBytes($bytes, $precision = 2)
+  {
+    $units = array('B', 'KB', 'MB', 'GB', 'TB');
+
+    $bytes = max($bytes, 0);
+    $pow = floor(($bytes ? log($bytes) : 0) / log(1024));
+    $pow = min($pow, count($units) - 1);
+
+    // Uncomment one of the following alternatives
+    $bytes /= pow(1024, $pow);
+    // $bytes /= (1 << (10 * $pow));
+
+    return round($bytes, $precision).' '.$units[$pow];
+  }
+
+  // Debug logging
+  public function debuglog($message)
+  {
+    if ($this->debug) {
+      printf("%s\n", $message);
     }
+  }
 }

--- a/ahsay-api-wrapper.php
+++ b/ahsay-api-wrapper.php
@@ -264,7 +264,7 @@ class AhsayApiWrapper
   public function listBackupJobStatus($username, $date)
   {
     if (isset($date) === false) {
-      $date = date("-Y-m-d");
+      $date = date("Y-m-d");
     }
 
     $this->debuglog("Getting status for backup job that run on the '$date' for user '$username'");

--- a/ahsay-api-wrapper.php
+++ b/ahsay-api-wrapper.php
@@ -28,6 +28,7 @@ class AhsayApiWrapper
   public $serverAddress;
   public $serverAdminUsername;
   public $serverAdminPassword;
+  public $serverVersion;
   public $debug;
   public $error;
 


### PR DESCRIPTION
I added the support for Ahsay OBS version 7.X API that return data in JSON but the wraper is still compatible with version 6.X.

I have only tested the version 6.X API trought an OBS version 7.X because he can still server API version 6.X through a specific URL but some informations can only be obtained trought the version 7.X.

I add some minor function like the errorHandler function to handle error returned by the API or the decodeResult function that decode the XML and JSON data and the runQuery was heavily moddified to support version 7.X API.

The getUserBackupJobDetails function now need and DestinationID parameter for 7.X clients so the function getDestinationID was added and the destination can only be retrieve trought listBackupJobStatus.do URI on the API so i added an listBackupJobStatus function.

You need to add '?w=1' to the compare URL on Github to avoid whitespace problem when you compare my files.
